### PR TITLE
Makefile: Make CC and CCFLAGS Configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+ifeq ($(origin CC),default)
 CC = gcc
-CFLAGS = -O -lz -Wall -g -Iinc -Iexternal/inc
+endif
+CFLAGS ?= -O -lz -Wall -g -Iinc -Iexternal/inc
 OBJ = bin/main.o bin/decrypt.o bin/ignorelist.o bin/ignored_extensions.o bin/snippets.o bin/scan.o bin/psi.o bin/keywords.o bin/match.o bin/report.o bin/copyright.o bin/vulnerability.o bin/quality.o bin/license.o bin/dependency.o bin/file.o bin/parse.o bin/query.o bin/debug.o bin/help.o bin/winnowing.o bin/crc32c.o bin/util.o bin/limits.o bin/json.o bin/rank.o bin/mz.o bin/attributions.o bin/cryptography.o bin/versions.o bin/url.o
  
  bin/%.o: src/%.c


### PR DESCRIPTION
Use weak assignment for CCFLAGS so it can respects predefined flags.

Make CC variable and therefore the compiler configurable by checking if
it is set already by using the origin function.
This is helpful to change the compiler version on the fly or to use a
specific compiler for a different platform.

Signed-off-by: Jens Erdmann <jens.erdmann@web.de>