### PR TITLE
Update snippets.c License Header Comment

### DIFF
--- a/src/snippets.c
+++ b/src/snippets.c
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: GPL-2.0-or-later
-*
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
 * src/snippets.c
 *
 * Snippet scanning subroutines


### PR DESCRIPTION
Changes `snippets.c` SPDX License Indicator comment line to favor license replacement scripts.