### PR TITLE
[bug fix] the logical error during the process of removing leading co…

### DIFF
--- a/src/versions.c
+++ b/src/versions.c
@@ -59,7 +59,7 @@ void normalise_version(char *version, char *component)
 	if ((version && component) && stristart(version, component))
 	{
 		int compt_len = strlen(component);
-		sprintf(aux, "%s",version + compt_len+1);
+		sprintf(version, "%s",version + compt_len);
 	}
 
 	/* Remove unwanted leading characters from the version */


### PR DESCRIPTION
…mponent name from version in function normalise_version()
input: AVPK, AVPK3.0.1
before: output: .0.1
after: output: 3.0.1